### PR TITLE
FadeOut sound

### DIFF
--- a/scene-transitions.js
+++ b/scene-transitions.js
@@ -88,9 +88,8 @@ class Transition {
 		
 		let time = (instant) ? 0:400;
 		clearTimeout(this.timeout);
+		if(this.audio !== null) this.fadeAudio(this.audio, time);
 		this.modal.fadeOut(time,()=>{
-			if(this.audio !== null)
-				this.audio.pause();
 			this.modal.remove();
 			this.modal = null;
 		})
@@ -110,6 +109,25 @@ class Transition {
 	getJournalImg(){
 		return this.journal.img;
 	}
+
+
+	fadeAudio(audio, time){
+		if(audio.volume){
+			let volume = audio.volume;
+			let targetVolume = 0;
+			let speed = volume / time * 100;  
+			audio.volume = volume;
+			let fade = function() {
+				volume -= speed;
+				audio.volume = volume.toFixed(1);
+				if(volume.toFixed(1) <= targetVolume){
+					clearInterval(audioFadeTimer);
+				};
+			}
+			fade();
+			let audioFadeTimer = setInterval(fade,100);
+		};
+	};
 }
 
 class TransitionForm extends FormApplication {


### PR DESCRIPTION
Hi Will
Hope all is well.

I've been playing with Scene Transitions in my games - here's the first mod I've made to fade out the sound along with the overlay.
Makes things a bit less jarring when they click out of my rock style intro that's triggered from a macro to let everyone the game is about to start.
Take a look, mess with it, would love to see this included as standard.

I'd love to see a way to specify the fade out time. I'm about to add this so I can configure it from a macro.
But I'm not sure how to approach setting this up on the UI side of things for normal transitions.

Cheers,
Mick