### PR TITLE
Add option to apply transition to specific players

### DIFF
--- a/scene-transitions.js
+++ b/scene-transitions.js
@@ -31,7 +31,7 @@ class Transition {
 		this.modal = null;
 		this.timeout = null;
 		this.audio = null;
-        
+		this.users = null;
 	}	
 	
 	
@@ -40,8 +40,8 @@ class Transition {
 			fontColor:'#ffffff',
 			fontSize:'28px',
 			bgImg:'',
-            bgPos:'center center',
-            bgSize:'cover',
+			bgPos:'center center',
+			bgSize:'cover',
 			bgColor:'#000000',
 			bgOpacity:0.7,
 			delay:5000,
@@ -345,8 +345,10 @@ class TransitionForm extends FormApplication {
 Hooks.on('init',() => {;
 	console.log('Scene Transition')
 	game.socket.on('module.scene-transitions', async (data) => {
-        console.log(data.sceneID,data.options)
-		new Transition(false,data.sceneID, data.options).render()
+		console.log(data.sceneID,data.options);
+		if (!data.users || data.users.contains(game.userId)) {
+			new Transition(false,data.sceneID, data.options).render();
+		}
 	})
    
 });


### PR DESCRIPTION
By setting an array of user IDs in `data.users`, only those users will see the scene transition. This allows for e.g. splitting the party / conveying non-universal information / etc.

This contribution only allows programmatic access (i.e. via macro), but could later be extended to the settings dialog.