### PR TITLE
0.8.3+ compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,30 @@ Allows GM to make simple transitions to show players before navigating to new sc
 Macro sample code:
 
 ```javascript
-let data = {
-	sceneID:false,
-	options:{
-		fontColor:'#ffffff',
-		fontSize:'28px',
-		bgImg:'', // pass any relative or absolute image url here.
-		bgPos:'center center',
-		bgSize:'cover',
-		bgColor:'#333333',
-		bgOpacity:0.7,
-		fadeIn: 400, //how long to fade in
-		delay:5000, //how long for transition to stay up
-		fadeOut: 400, //how long to fade out
-		skippable:true, //Allows players to skip transition with a click before delay runs out.
-		content:"TEST MACRO",
-		audio: "" //path to audio file
-	}
-}
-
-activeTransition = new Transition(false, data.sceneID, data.options) //
-activeTransition.render()// These 2 lines can be omitted if you don't want to personally see the transition.
-game.socket.emit('module.scene-transitions', data);
+Transition.macro({
+	sceneID:false, // scene id of the scene to transition to (false for none)
+	fontColor:'#ffffff',
+	fontSize:'28px',
+	content:"TEST MACRO",
+	bgImg:'', // pass any relative or absolute image url here.
+	bgPos:'center center',
+	bgSize:'cover',
+	bgColor:'#333333',
+	bgOpacity:0.7,
+	fadeIn: 400, //how long to fade in
+	delay:5000, //how long for transition to stay up
+	fadeOut: 400, //how long to fade out
+	audio: "" //path to audio file
+	volume: 1.0 //volume of audio
+	skippable:true, //Allows players to skip transition with a click before delay runs out.
+})
 ```
-To play a transition without a scene activation, simple pass `false` as the sceneID in the data object.
+
+# 0.1.1
+Foundry 0.8.2+ compatability
+Use Web Audio API for Audio
+New simplified macro (the old way still works, but is deprecated)
+Removed variables in the global namespace
 
 # 0.0.9
 Play as Transition from Journal top bar can be hidden in the module settings  

--- a/README.md
+++ b/README.md
@@ -4,30 +4,30 @@ Allows GM to make simple transitions to show players before navigating to new sc
 Macro sample code:
 
 ```javascript
-Transition.macro({
-	sceneID:false, // scene id of the scene to transition to (false for none)
-	fontColor:'#ffffff',
-	fontSize:'28px',
-	content:"TEST MACRO",
-	bgImg:'', // pass any relative or absolute image url here.
-	bgPos:'center center',
-	bgSize:'cover',
-	bgColor:'#333333',
-	bgOpacity:0.7,
-	fadeIn: 400, //how long to fade in
-	delay:5000, //how long for transition to stay up
-	fadeOut: 400, //how long to fade out
-	audio: "" //path to audio file
-	volume: 1.0 //volume of audio
-	skippable:true, //Allows players to skip transition with a click before delay runs out.
-})
-```
+let data = {
+	sceneID:false,
+	options:{
+		fontColor:'#ffffff',
+		fontSize:'28px',
+		bgImg:'', // pass any relative or absolute image url here.
+		bgPos:'center center',
+		bgSize:'cover',
+		bgColor:'#333333',
+		bgOpacity:0.7,
+		fadeIn: 400 //how long to fade in
+		delay:5000, //how long for transition to stay up
+		fadeOut: 400 //how long to fade out
+		skippable:true, //Allows players to skip transition with a click before delay runs out.
+		content:"TEST MACRO",
+		audio: "" //path to audio file
+	}
+}
 
-# 0.1.1
-Foundry 0.8.2+ compatability
-Use Web Audio API for Audio
-New simplified macro (the old way still works, but is deprecated)
-Removed variables in the global namespace
+activeTransition = new Transition(false, data.sceneID, data.options) //
+activeTransition.render()// These 2 lines can be omitted if you don't want to personally see the transition.
+game.socket.emit('module.scene-transitions', data);
+```
+To play a transition without a scene activation, simple pass `false` as the sceneID in the data object.
 
 # 0.0.9
 Play as Transition from Journal top bar can be hidden in the module settings  

--- a/README.md
+++ b/README.md
@@ -4,30 +4,37 @@ Allows GM to make simple transitions to show players before navigating to new sc
 Macro sample code:
 
 ```javascript
-let data = {
-	sceneID:false,
-	options:{
-		fontColor:'#ffffff',
-		fontSize:'28px',
-		bgImg:'', // pass any relative or absolute image url here.
-		bgPos:'center center',
-		bgSize:'cover',
-		bgColor:'#333333',
-		bgOpacity:0.7,
-		fadeIn: 400 //how long to fade in
-		delay:5000, //how long for transition to stay up
-		fadeOut: 400 //how long to fade out
-		skippable:true, //Allows players to skip transition with a click before delay runs out.
-		content:"TEST MACRO",
-		audio: "" //path to audio file
-	}
-}
+/**
+ * Transition.macro(options, showMe)
+ */
+Transistion.macro({
+	sceneID: false,
+	content:"TEST MACRO",
+	fontColor:'#ffffff',
+	fontSize:'28px',
+	bgImg:'', // pass any relative or absolute image url here.
+	bgPos:'center center',
+	bgSize:'cover',
+	bgColor:'#333333',
+	bgOpacity:0.7,
+	fadeIn: 400, //how long to fade in
+	delay:5000, //how long for transition to stay up
+	fadeOut: 400 //how long to fade out
+	audio: "" //path to audio file
+	skippable:true, //Allows players to skip transition with a click before delay runs out.
+	gmHide: true, // hide the transistion on other windows logged in as a GM
+	gmEndAll: true, // whwn the fm clicks to end the transition - end for everyone
 
-activeTransition = new Transition(false, data.sceneID, data.options) //
-activeTransition.render()// These 2 lines can be omitted if you don't want to personally see the transition.
-game.socket.emit('module.scene-transitions', data);
+}, true ) //show to the triggering user
 ```
 To play a transition without a scene activation, simple pass `false` as the sceneID in the data object.
+
+# 0.1.1
+FVTT 0.8.2+ compatability  
+Use new WebAudio API for sound (0.8.2+)  
+Added option to hide transition on other GM broswer windows (default true)
+Added option to end the transition when the GM ends iy (deafult true)
+Refactor to clean up global namespace  
 
 # 0.0.9
 Play as Transition from Journal top bar can be hidden in the module settings  

--- a/module.json
+++ b/module.json
@@ -3,9 +3,9 @@
   "title": "Scene Transitions",
   "description": "Create transition between scenes.",
   "authors": ["Will Saunders","DM_miX"],
-  "version": "0.0.9",
+  "version": "0.1.1",
   "minimumCoreVersion": "0.7.9",
-  "compatibleCoreVersion":"0.8.1",
+  "compatibleCoreVersion":"0.8.8",
   "scripts": [
   	"scene-transitions.js"
   ],

--- a/scene-transitions.js
+++ b/scene-transitions.js
@@ -50,7 +50,7 @@
 	static get defaultOptions(){
 		return{
             sceneID: false,
-            hideGM: true,
+            gmHide: true,
 			fontColor:'#777777',
 			fontSize:'28px',
 			bgImg:'',
@@ -202,7 +202,7 @@
 
 	render(){
         Transition.activeTransition = this;
-        if(this.options.hideGM && this.options.fromSocket && game.user.isGM) {
+        if(this.options.gmHide && this.options.fromSocket && game.user.isGM) {
             return;
         }
 
@@ -258,7 +258,7 @@
 			if(!this.preview)
 				this.setDelay();
 		})
-		if(this.options.skippable && !this.preview){
+		if((this.options.skippable && !this.preview) || (this.options.gmEndAll && game.user.isGM && !this.preview)){
 			this.modal.on('click',()=>{
                 if(this.options.gmEndAll && game.user.isGM) {
                     game.socket.emit('module.scene-transitions', {action: "end"});

--- a/templates/transition-form.html
+++ b/templates/transition-form.html
@@ -101,6 +101,16 @@
             <input type="checkbox" name="skippable" data-dtype="Boolean" {{checked skippable}}/>
             <p class="notes">Allow user to end transition before timer ends.</p>
         </div>
+        <div class="form-group">
+            <label>GM ends for all</label>
+            <input type="checkbox" name="gmEndAll" data-dtype="Boolean" {{checked gmEndAll}}/>
+            <p class="notes">If the GM ends the transition, end for everyone</p>
+        </div>
+        <div class="form-group">
+            <label>Don't show other GM windows</label>
+            <input type="checkbox" name="hideGM" data-dtype="Boolean" {{checked hideGM}}/>
+            <p class="notes">Don't show on other windows logged in as a GM.</p>
+        </div>
     </div>
 
 

--- a/templates/transition-form.html
+++ b/templates/transition-form.html
@@ -108,7 +108,7 @@
         </div>
         <div class="form-group">
             <label>Don't show other GM windows</label>
-            <input type="checkbox" name="hideGM" data-dtype="Boolean" {{checked hideGM}}/>
+            <input type="checkbox" name="gmHide" data-dtype="Boolean" {{checked gmHide}}/>
             <p class="notes">Don't show on other windows logged in as a GM.</p>
         </div>
     </div>

--- a/templates/transition-form.html
+++ b/templates/transition-form.html
@@ -26,15 +26,14 @@
                 <input type="text" name="bgOpacity" placeholder="0.7" value="{{bgOpacity}}">
             </div>
         </div>
+
         <div class="form-group">
              <label>{{localize "SCENES.BackgroundColor"}}</label>
             <div class="form-fields">
-                {{colorPicker target="bgColor" }}
-               <input type="text" name="bgColor" value="{{bgColor}}" data-dtype="String"/>
-                <input type="color" value="{{bgColor}}" data-edit="bgColor"/>
-
+                {{ colorPicker name="bgColor" value=bgColor }}
             </div>
         </div>
+
         <div class="form-group">
             <label>Background Size</label>
             <input type="text" name="bgSize" placeholder="cover" value="{{bgSize}}">
@@ -47,14 +46,14 @@
             <label>Font Size</label>
             <input type="text" name="fontSize" placeholder="28px" value="{{fontSize}}">
         </div>
+        
         <div class="form-group">
             <label>Font Color</label>
             <div class="form-fields">
-                {{colorPicker target="fontColor" }}
-                <input type="text" name="fontColor" value="{{fontColor}}" data-dtype="String"/>
-                <input type="color" value="{{fontColor}}" data-edit="fontColor"/>
+                {{ colorPicker name="fontColor" value=fontColor }}
             </div>
         </div>
+        
         <!--- Transition text -->
         <div style="margin-top:10px">
             <label>Transition Text</label>


### PR DESCRIPTION
# 0.1.1
New helper for macros - Transition.macro(options, showMe)  
Use new WebAudio API for sound (0.8.2+)  
Added option to hide transition on other GM broswer windows (default true)
Added option to end the transition when the GM ends iy (deafult true)
Refactor to clean up global namespace  
Refactor sceneID to be part of options object for simplictity
FVTT 0.8.2+ compatability  